### PR TITLE
Required model in lib, to prevent unitialized constant error.

### DIFF
--- a/lib/tiddle.rb
+++ b/lib/tiddle.rb
@@ -1,4 +1,5 @@
 require "tiddle/version"
+require "tiddle/model"
 require "tiddle/strategy"
 require "tiddle/rails"
 require "tiddle/token_issuer"


### PR DESCRIPTION
I was trying to use the Tiddle gem, but got this error: ```/Users/Code/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/devise-3.4.1/lib/devise/models.rb:88:in `const_get': uninitialized constant Devise::Models::TokenAuthenticatable (NameError)
	from /Users/Code/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/devise-3.4.1/lib/devise/models.rb:88:in `block (2 levels) in devise'
	from /Users/Code/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/devise-3.4.1/lib/devise/models.rb:87:in `each'
	from /Users/Code/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/devise-3.4.1/lib/devise/models.rb:87:in `block in devise'
	from /Users/Code/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/devise-3.4.1/lib/devise/models.rb:114:in `devise_modules_hook!'
	from /Users/Code/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/devise-3.4.1/lib/devise/models.rb:84:in `devise'```

So I required the model in the Lib folder, and Rails now runs without errors. 