### PR TITLE
Added documentation about session create method

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ end
 class Users::SessionsController < Devise::SessionsController
 
   def create
-    [...]
+    self.resource = warden.authenticate!(auth_options)
+    # ^Or whatever custom logic you would like to use here.
     token = Tiddle.create_and_return_token(resource, request)
     render json: { authentication_token: token }
   end


### PR DESCRIPTION
When I was writing the Create method in the sessions controller, realized I needed to define what "resource" was (the warden.authenticate). Saw how it was defined on your blog post at http://adamniedzielski.github.io/blog/2015/04/04/token-authentication-with-tiddle. Added a note to the docs on how to do that.