### PR TITLE
Allowed Devise to be updated to 3.5.1

### DIFF
--- a/tiddle.gemspec
+++ b/tiddle.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.1.0'
 
-  spec.add_dependency "devise", "~> 3.4.1"
+  spec.add_dependency "devise", "~> 3.4"
   spec.add_dependency "activerecord", "~> 4.2.0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I had an issue with Tiddle blocking my app from being updated to Devise 3.5.1.

I've tested the changes with the bumped version of Devise with no real issues so far.

Hope this helps.