### PR TITLE
Only Token Digest should be saved to the Database

### DIFF
--- a/spec/tiddle_spec.rb
+++ b/spec/tiddle_spec.rb
@@ -9,6 +9,12 @@ describe Tiddle do
     it "returns string with token" do
       result = Tiddle.create_and_return_token(@user, FakeRequest.new)
       expect(result).to be_present
+      expect(result).to be_kind_of(String)
+    end
+
+    it "stores a different string to the database" do
+      result = Tiddle.create_and_return_token(@user, FakeRequest.new)
+      expect(result).to_not eq @user.authentication_tokens.last.body
     end
 
     it "creates new token in the database" do


### PR DESCRIPTION
I noticed Tiddle returns the same Token it saves to the Database, that might very well be a vulnerability in itself.

I took some inspiration from Devise, and used its [TokenGenerator](https://github.com/plataformatec/devise/blob/master/lib/devise/token_generator.rb) to generate a token and a digest. The token gets returned to the user, while the digest gets saved to the DB.

I've done this while maintaining the same API, so it should be an easy upgrade. It will prevent any existing tokens from working, but that shouldn't be too much of an issue as users can just request another token.

Additionally, I squelched some Rubocop alerts by changing line length to 100, and fixed some issues I was having running the specs by adding `require 'bundler/setup'` to `spec_helper.rb`