### PR TITLE
Allow auth by multiple authentication_keys

### DIFF
--- a/lib/tiddle/strategy.rb
+++ b/lib/tiddle/strategy.rb
@@ -9,7 +9,8 @@ module Devise
       def authenticate!
         env["devise.skip_trackable"] = true
 
-        resource = mapping.to.find_for_authentication(email: email_from_headers)
+        Rails.logger.debug authentication_keys_from_headers
+        resource = mapping.to.find_for_authentication(*authentication_keys_from_headers)
         return fail(:invalid_token) unless resource
 
         token = Tiddle::TokenIssuer.build.find_token(resource, token_from_headers)
@@ -22,7 +23,7 @@ module Devise
       end
 
       def valid?
-        email_from_headers.present? && token_from_headers.present?
+        authentication_keys_from_headers.present? && token_from_headers.present?
       end
 
       def store?
@@ -31,8 +32,8 @@ module Devise
 
       private
 
-        def email_from_headers
-          env["HTTP_X_#{model_name}_EMAIL"]
+        def authentication_keys_from_headers
+          authentication_keys.map{|key| {key => env["HTTP_X_#{model_name}_#{key.upcase}"]}}.reduce(:merge)
         end
 
         def token_from_headers
@@ -41,6 +42,10 @@ module Devise
 
         def model_name
           Tiddle::ModelName.new.with_underscores(mapping.to)
+        end
+
+        def authentication_keys
+          Devise.authentication_keys
         end
 
         def touch_token(token)

--- a/lib/tiddle/strategy.rb
+++ b/lib/tiddle/strategy.rb
@@ -9,7 +9,7 @@ module Devise
       def authenticate!
         env["devise.skip_trackable"] = true
 
-        resource = mapping.to.find_for_authentication(*authentication_keys_from_headers)
+        resource = mapping.to.find_for_authentication(authentication_keys_from_headers)
         return fail(:invalid_token) unless resource
 
         token = Tiddle::TokenIssuer.build.find_token(resource, token_from_headers)

--- a/lib/tiddle/strategy.rb
+++ b/lib/tiddle/strategy.rb
@@ -9,7 +9,6 @@ module Devise
       def authenticate!
         env["devise.skip_trackable"] = true
 
-        Rails.logger.debug authentication_keys_from_headers
         resource = mapping.to.find_for_authentication(*authentication_keys_from_headers)
         return fail(:invalid_token) unless resource
 


### PR DESCRIPTION
I need authenticate with login attribute and not email. Then, i propose this change that reads the authentication_keys from devise config.