### PR TITLE
Remove unnecessary secure compare when fetching tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ end
 2) Generate the model which stores authentication tokens. The model name is not important, but the Devise-enabled model should have association called ```authentication_tokens```.
 
 ```
-rails g model AuthenticationToken body:string user:references last_used_at:datetime ip_address:string user_agent:string
+rails g model AuthenticationToken body:string:index user:references last_used_at:datetime ip_address:string user_agent:string
 ```
 
 ```ruby

--- a/lib/tiddle/token_issuer.rb
+++ b/lib/tiddle/token_issuer.rb
@@ -33,9 +33,7 @@ module Tiddle
     def find_token(resource, token_from_headers)
       token_class = authentication_token_class(resource)
       token_body = Devise.token_generator.digest(token_class, :body, token_from_headers)
-      resource.authentication_tokens.detect do |token|
-        Devise.secure_compare(token.body, token_body)
-      end
+      resource.authentication_tokens.find_by(body: token_body)
     end
 
     def purge_old_tokens(resource)


### PR DESCRIPTION
Removing  unnecessary secure compare when fetching token using #find_by instead of #detect
Addressing #35 issue