### PR TITLE
Add support for ruby 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem update --system
 rvm:
   - "2.2.8"
   - "2.3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - "2.2.8"
   - "2.3.5"
   - "2.4.2"
+  - "2.5.0"
 gemfile:
   - "gemfiles/rails4.2.gemfile"
   - "gemfiles/rails5.0.gemfile"

--- a/tiddle.gemspec
+++ b/tiddle.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_dependency "devise", ">= 4.0.0.rc1", "< 4.4"
+  spec.add_dependency "devise", ">= 4.0.0.rc1", "< 4.5"
   spec.add_dependency "activerecord", ">= 4.2.0"
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
Hello,
If you want ruby 2.5.0 you have no choice but to use devise 4.5 I've run all tests locally and they seem to be fine.
It should resolve issue #38 