### PR TITLE
Updating last_used_at on every token usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,13 @@ Tokens are expiring after certain period of inactivity. This behavior is optiona
 ```ruby
 token = Tiddle.create_and_return_token(user, request, expires_in: 1.month)
 ```
+
+## Configuration
+
+Tiddle accepts some extra configuration
+
+```ruby
+Tiddle.configure do |config|
+  config.touch_token_interval = 1.hour # How often we will update last_activity_at field on tokens when they are used
+end
+```

--- a/lib/tiddle.rb
+++ b/lib/tiddle.rb
@@ -1,10 +1,23 @@
 require "tiddle/version"
+require "tiddle/configuration"
 require "tiddle/model"
 require "tiddle/strategy"
 require "tiddle/rails"
 require "tiddle/token_issuer"
 
 module Tiddle
+  def self.configuration
+    @configuration ||= Configuration.new
+  end
+
+  def self.reset_configuration
+    @configuration = Configuration.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
   def self.create_and_return_token(resource, request, options = {})
     TokenIssuer.build.create_and_return_token(resource, request, options)
   end

--- a/lib/tiddle/configuration.rb
+++ b/lib/tiddle/configuration.rb
@@ -1,0 +1,9 @@
+module Tiddle
+  class Configuration
+    attr_accessor :touch_token_interval
+
+    def initialize
+      self.touch_token_interval = 1.hour
+    end
+  end
+end

--- a/lib/tiddle/strategy.rb
+++ b/lib/tiddle/strategy.rb
@@ -49,7 +49,7 @@ module Devise
       end
 
       def touch_token(token)
-        token.update_attribute(:last_used_at, Time.current) if token.last_used_at < 1.hour.ago
+        token.update_attribute(:last_used_at, Time.current)
       end
 
       def unexpired?(token)

--- a/lib/tiddle/strategy.rb
+++ b/lib/tiddle/strategy.rb
@@ -49,7 +49,8 @@ module Devise
       end
 
       def touch_token(token)
-        token.update_attribute(:last_used_at, Time.current)
+        token.update_attribute(:last_used_at, Time.current) if
+          token.last_used_at < Tiddle.configuration.touch_token_interval.ago
       end
 
       def unexpired?(token)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,6 +74,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean if defined?(DatabaseCleaner)
   end
 
+  config.after(:each) do
+    Tiddle.reset_configuration
+  end
+
   config.use_transactional_fixtures = true
 
 # The settings below are suggested to provide a good initial experience

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -38,6 +38,25 @@ describe "Authentication using Tiddle strategy", type: :request do
 
       context "when token was last used less than hour ago" do
         before do
+          @user.authentication_tokens.last.update_attribute(:last_used_at, 30.minutes.ago)
+        end
+
+        it "does not update last_used_at field" do
+          expect do
+            warningless_get(
+              secrets_path,
+              headers: {
+                "X-USER-EMAIL" => "test@example.com",
+                "X-USER-TOKEN" => @token
+              }
+            )
+          end.not_to(change { @user.reload.authentication_tokens.last.last_used_at })
+        end
+      end
+
+      context "when using a custom configuration time and token was last used less than hour ago" do
+        before do
+          Tiddle.configuration.touch_token_interval = 5.minutes
           @user.authentication_tokens.last.update_attribute(:last_used_at, 10.minutes.ago)
         end
 

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -38,10 +38,10 @@ describe "Authentication using Tiddle strategy", type: :request do
 
       context "when token was last used less than hour ago" do
         before do
-          @user.authentication_tokens.last.update_attribute(:last_used_at, 30.minutes.ago)
+          @user.authentication_tokens.last.update_attribute(:last_used_at, 10.minutes.ago)
         end
 
-        it "does not update last_used_at field" do
+        it "updates last_used_at field" do
           expect do
             warningless_get(
               secrets_path,
@@ -50,7 +50,7 @@ describe "Authentication using Tiddle strategy", type: :request do
                 "X-USER-TOKEN" => @token
               }
             )
-          end.not_to(change { @user.authentication_tokens.last.last_used_at })
+          end.to(change { @user.reload.authentication_tokens.last.last_used_at })
         end
       end
     end


### PR DESCRIPTION
Fix https://github.com/adamniedzielski/tiddle/issues/56

Removed the check to update last_activity_at only if token last_activity_at was greater than 1 hour ago.