### PR TITLE
Allow maximum_tokens_per_user to be set when purging

### DIFF
--- a/lib/tiddle.rb
+++ b/lib/tiddle.rb
@@ -13,8 +13,8 @@ module Tiddle
     TokenIssuer.build.expire_token(resource, request)
   end
 
-  def self.purge_old_tokens(resource)
-    TokenIssuer.build.purge_old_tokens(resource)
+  def self.purge_old_tokens(resource, maximum_tokens_per_user: TokenIssuer.MAXIMUM_TOKENS_PER_USER)
+    TokenIssuer.build.purge_old_tokens(resource, maximum_tokens_per_user: maximum_tokens_per_user)
   end
 end
 

--- a/lib/tiddle/token_issuer.rb
+++ b/lib/tiddle/token_issuer.rb
@@ -9,7 +9,7 @@ module Tiddle
     end
 
     def initialize(maximum_tokens_per_user)
-      self.maximum_tokens_per_user = maximum_tokens_per_user
+      @maximum_tokens_per_user = maximum_tokens_per_user
     end
 
     def create_and_return_token(resource, request, expires_in: nil)
@@ -35,7 +35,7 @@ module Tiddle
       resource.authentication_tokens.where(body: token_body).first
     end
 
-    def purge_old_tokens(resource)
+    def purge_old_tokens(resource, maximum_tokens_per_user: @maximum_tokens_per_user)
       resource.authentication_tokens
               .order(last_used_at: :desc)
               .offset(maximum_tokens_per_user)
@@ -43,8 +43,6 @@ module Tiddle
     end
 
     private
-
-    attr_accessor :maximum_tokens_per_user
 
     def authentication_token_class(resource)
       if resource.respond_to?(:association) # ActiveRecord

--- a/spec/tiddle_spec.rb
+++ b/spec/tiddle_spec.rb
@@ -86,8 +86,16 @@ describe Tiddle do
 
     it "deletes old tokens which are over the limit" do
       expect do
-        Tiddle::TokenIssuer.new(1).purge_old_tokens(@user)
+        Tiddle.purge_old_tokens(@user, maximum_tokens_per_user: 1)
       end.to change { @user.authentication_tokens.count }.from(2).to(1)
+
+      expect(@user.authentication_tokens.last).to eq @new
+    end
+
+    it "keeps tokens when under the limit" do
+      expect do
+        Tiddle.purge_old_tokens(@user, maximum_tokens_per_user: 2)
+      end.not_to(change { @user.authentication_tokens.count }.from(2))
 
       expect(@user.authentication_tokens.last).to eq @new
     end


### PR DESCRIPTION
I wanted to purge some tokens, but I wanted to use the shorthand `Tiddle.purge_old_tokens` instead of creating a `TokenIssuer` instance.

I changed the shorthand to accept a `maximum_tokens_per_user` argument, with a backwards compatible fallback which should avoid the need for any code changes when using this gem.