### PR TITLE
Skip CSRF clean up for token strategy

### DIFF
--- a/lib/tiddle/strategy.rb
+++ b/lib/tiddle/strategy.rb
@@ -28,6 +28,14 @@ module Devise
         false
       end
 
+      # Avoid CSRF clean up for token authentication as it might trigger session creation in API
+      # environments even if CSRF prevention is not being used.
+      # Devise provides a `clean_up_csrf_token_on_authentication` option but it's not always viable
+      # in applications with multiple user models and authentication strategies.
+      def clean_up_csrf?
+        false
+      end
+
       private
 
       def authentication_keys_from_headers


### PR DESCRIPTION
Hi @adamniedzielski 

I ran into an issue in an app with multiple auth models and sessions enabled where new sessions where created for each token authentication because devise triggers session creation when trying to clean up CSRF tokens after authentication.

https://github.com/heartcombo/devise/blob/715192a7709a4c02127afb067e66230061b82cf2/lib/devise/hooks/csrf_cleaner.rb#L7

My understanding is that having this clean up enabled is irrelevant for token authentication but I might be wrong.

Please LMK what you think.

Thanks,
