### PR TITLE
[Ruby 2.7] Fix last argument as keyword parameter error 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - "2.4.6"
   - "2.5.5"
   - "2.6.3"
+  - "2.7.1"
 gemfile:
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.2.gemfile
@@ -22,3 +23,5 @@ jobs:
   exclude:
   - rvm: "2.4.6"
     gemfile: gemfiles/rails6.0.gemfile
+  - rvm: "2.7.1"
+    gemfile: gemfiles/rails4.2.gemfile

--- a/lib/tiddle.rb
+++ b/lib/tiddle.rb
@@ -6,7 +6,7 @@ require "tiddle/token_issuer"
 
 module Tiddle
   def self.create_and_return_token(resource, request, options = {})
-    TokenIssuer.build.create_and_return_token(resource, request, options)
+    TokenIssuer.build.create_and_return_token(resource, request, **options)
   end
 
   def self.expire_token(resource, request)

--- a/tiddle.gemspec
+++ b/tiddle.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "devise", ">= 4.0.0.rc1", "< 5"
   spec.add_dependency "activerecord", ">= 4.2.0"
-  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "appraisal"


### PR DESCRIPTION
- `warning: Using the last argument as keyword parameters is deprecated, maybe ** should be added to the call `
- This deprecation was added in [ruby 2.7](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)

Was getting a deprecation warning on this line