### PR TITLE
Fix "last argument as keyword" warning for ruby 2.7.0+

### DIFF
--- a/lib/tiddle.rb
+++ b/lib/tiddle.rb
@@ -6,7 +6,7 @@ require "tiddle/token_issuer"
 
 module Tiddle
   def self.create_and_return_token(resource, request, options = {})
-    TokenIssuer.build.create_and_return_token(resource, request, options)
+    TokenIssuer.build.create_and_return_token(resource, request, **options)
   end
 
   def self.expire_token(resource, request)


### PR DESCRIPTION
Remove warning about using the last argument as keyword parameter.
https://piechowski.io/post/last-arg-keyword-deprecated-ruby-2-7/