### PR TITLE
Token is not expired when devise resource is nested inside a module because of wrong header name

### DIFF
--- a/lib/tiddle/token_issuer.rb
+++ b/lib/tiddle/token_issuer.rb
@@ -24,7 +24,7 @@ module Tiddle
     end
 
     def expire_token(resource, request)
-      find_token(resource, request.headers["X-#{ModelName.new.with_dashes(resource)}-TOKEN"])
+      find_token(resource, request.headers[token_header_for(resource)])
         .try(:destroy)
     end
 
@@ -69,6 +69,10 @@ module Tiddle
       else
         attributes
       end
+    end
+
+    def token_header_for(resource)
+      "HTTP_X_#{Tiddle::ModelName.new.with_underscores(resource)}_TOKEN"
     end
   end
 end


### PR DESCRIPTION
Hi!

This bug arises only when the associated devise resource is nested inside a module as `ModelName#with_underscores(model)` relies on the `String#underscore` ActiveSupport method that translates a "::" into a "/". Basically, the `TokenIssuer` constructs the header name for the token in different way than the `TokenAuthenticatable` strategy.

For example let's say that the model is named `Admin::User`, then `"X-#{ModelName.new.with_dashes(resource)}-TOKEN"` (https://github.com/adamniedzielski/tiddle/blob/b381765d0458e254da5a4cdf4c291736e5dcfc03/lib/tiddle/token_issuer.rb#L27) gets converted to "X-ADMIN/USER-TOKEN".

But when it trys to access the `request.headers` Rails, becuase of the slash, is not normalizing it to the correct "HTTP_X_ADMIN/USER-TOKEN" as can be seen on https://github.com/rails/rails/blob/6ef39975d60cc9dafd1728c49e394dad11d12327/actionpack/lib/action_dispatch/http/headers.rb#L123.

This patch solves this by using the exact way of constructing the header name in `TokenIssuer` as in `TokenAuthenticatable`.


