### PR TITLE
Header name construction is faulted when the devise resource is nested inside a module

### DIFF
--- a/lib/tiddle/model_name.rb
+++ b/lib/tiddle/model_name.rb
@@ -1,7 +1,7 @@
 module Tiddle
   class ModelName
     def with_underscores(model)
-      model.model_name.to_s.underscore.upcase
+      model.model_name.to_s.underscore.tr('/', '_').upcase
     end
 
     def with_dashes(model)


### PR DESCRIPTION
This PR is related to #63. 

```
module Tiddle
  class ModelName
    def with_underscores(model)
      model.model_name.to_s.underscore.upcase
    end
```

This method is using `#underscore` from ActiveSupport wich converts "::" to "/". The problem is that an slash is not valid inside a HTTP Header name which will be returned if model is nested inside a module (e.g. `Admin::User` => "ADMIN/USER"). This patch converts the slash into a "_".