### PR TITLE
Setup a docker dev environment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,25 @@
 3. Introduce your change. If it's a new feature then write a test for it as well.
 4. Make sure that tests are passing.
 5. Push to your fork and submit a pull request.
+
+#### Docker for development
+
+Alternatively you can use Docker for the development setup. This requires Docker
+and Docker Compose installed.
+
+```
+make build
+make bundle
+```
+
+And in order to run the tests and linter checks:
+
+```
+make test
+```
+
+After you're done, cleanup leftover containers:
+
+```
+make cleanup
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:3.0.4-alpine
+
+RUN apk add build-base sqlite-dev tzdata git bash
+RUN gem update --system && gem install bundler
+
+WORKDIR /library
+
+ENV BUNDLE_PATH=/vendor/bundle \
+    BUNDLE_BIN=/vendor/bundle/bin \
+    GEM_HOME=/vendor/bundle
+
+ENV PATH="${BUNDLE_BIN}:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2-alpine
+FROM ruby:3.1-alpine
 
 RUN apk add build-base sqlite-dev tzdata git bash
 RUN gem update --system && gem install bundler

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0.4-alpine
+FROM ruby:3.1.2-alpine
 
 RUN apk add build-base sqlite-dev tzdata git bash
 RUN gem update --system && gem install bundler

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build bundle test bash
+.PHONY: build bundle test bash cleanup
 
 build:
 	docker-compose build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build bundle test bash
+
+build:
+	docker-compose build
+
+bundle:
+	docker-compose run --rm library bundle install
+
+test:
+	docker-compose run --rm library bundle exec rake
+
+bash:
+	docker-compose run --rm library bash
+
+cleanup:
+	docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - redis
     environment:
       - REDIS_URL=redis://redis:6379/1
+      - BUNDLE_GEMFILE=gemfiles/rails7.0.gemfile
   redis:
     image: "redis:6-alpine"
     command: redis-server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3.9"
+services:
+  library:
+    build:
+      context: .
+    stdin_open: true
+    tty: true
+    volumes:
+      - ".:/library"
+      - vendor:/vendor
+    depends_on:
+      - redis
+    environment:
+      - REDIS_URL=redis://redis:6379/1
+  redis:
+    image: "redis:6-alpine"
+    command: redis-server
+    volumes:
+      - "redis:/data"
+volumes:
+  vendor:
+  redis:


### PR DESCRIPTION
Solves #88

I pretty much copied your contribution to Sidekiq and made it work for Tiddle.

I felt the need to add a `cleanup` step in the Makefile as the redis container wouldn't be automatically removed after running the tests.

Successfully tested on macOS using the gemfile for rails 6.1, using both ruby 3.0.4 and 2.7.6.

Didn't test with mongo. I'm not sure how to add a mongo configuration without adding a separate docker-compose.yml or always running mongo even when it's not needed.

Let me know what can be improved here.