### PR TITLE
Support lower touch token interval for short term tokens

### DIFF
--- a/lib/tiddle/strategy.rb
+++ b/lib/tiddle/strategy.rb
@@ -57,14 +57,27 @@ module Devise
       end
 
       def touch_token(token)
-        token.update_attribute(:last_used_at, Time.current) if token.last_used_at < 1.hour.ago
+        return unless token.last_used_at < touch_token_interval(token).ago
+
+        token.update_attribute(:last_used_at, Time.current)
       end
 
       def unexpired?(token)
-        return true unless token.respond_to?(:expires_in)
-        return true if token.expires_in.blank? || token.expires_in.zero?
+        return true if expiration_disabled?(token)
 
         Time.current <= token.last_used_at + token.expires_in
+      end
+
+      def touch_token_interval(token)
+        return 1.hour if expiration_disabled?(token) || token.expires_in >= 2.hours
+
+        1.minute
+      end
+
+      def expiration_disabled?(token)
+        !token.respond_to?(:expires_in) ||
+          token.expires_in.blank? ||
+          token.expires_in.zero?
       end
     end
   end

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -237,7 +237,7 @@ describe "Authentication using Tiddle strategy", type: :request do
                 "X-USER-TOKEN" => @token
               }
             )
-          end.not_to(change { @user.authentication_tokens.last.last_used_at })
+          end.not_to(change { @user.authentication_tokens.last.reload.last_used_at })
         end
       end
 
@@ -255,7 +255,7 @@ describe "Authentication using Tiddle strategy", type: :request do
                 "X-USER-TOKEN" => @token
               }
             )
-          end.to(change { @user.authentication_tokens.last.last_used_at })
+          end.to(change { @user.authentication_tokens.last.reload.last_used_at })
         end
       end
     end

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -246,7 +246,7 @@ describe "Authentication using Tiddle strategy", type: :request do
           @user.authentication_tokens.last.update_attribute(:last_used_at, 1.minute.ago)
         end
 
-        it "does not update last_used_at field" do
+        it "updates last_used_at field" do
           expect do
             get(
               secrets_path,


### PR DESCRIPTION
We need a way to support idle time in tokens with a lifetime lower than 1 hour.

This topic was already discussed in https://github.com/adamniedzielski/tiddle/issues/56 and https://github.com/adamniedzielski/tiddle/pull/57

I understood that this library doesn't want to be configurable. With that in mind, I made an approach that can work in both scenarios without introducing significant impact for who already uses the library.

The idea is to define the interval in which we touch the `last_used_at` field with a different touch interval for tokens with an expiration time of less than two hours.

I believe that one minute considerably reduces the interactions with the database. For a token with less than 1 hour of expiration time, it works for all the cases because one minute is a unit that works for any amount of time between one minute to one hour.

The token will be touched as before for those who don't have an expiration time defined or greater or equal two hours.

I've added some tests to the cover the new behavior.