### PR TITLE
fix(security): relax devise constraint to allow devise 5.x

### DIFF
--- a/lib/tiddle/version.rb
+++ b/lib/tiddle/version.rb
@@ -1,3 +1,3 @@
 module Tiddle
-  VERSION = "1.8.0".freeze
+  VERSION = "1.8.2".freeze
 end

--- a/tiddle.gemspec
+++ b/tiddle.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.7.0'
 
-  spec.add_dependency "devise", ">= 4.0.0.rc1", "< 5"
+  spec.add_dependency "devise", ">= 4.0.0.rc1", "< 6"
   spec.add_dependency "activerecord", ">= 5.2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
Relaxes the devise dependency from `< 5` to `< 6` to allow consumers to upgrade to devise 5.0.3 which fixes CVE-2026-32700 (confirmable race condition).

Tiddle uses only stable Devise APIs (Devise.add_module, Devise::Strategies::Authenticatable, Devise.token_generator) that are unchanged in devise 5.x.