### PR TITLE
Add Rails 7.2, 8.0 & 8.1 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,25 +12,38 @@ jobs:
       fail-fast: false
       matrix:
         gemfile:
-          - rails6.1
-          - rails7.0
-          - rails7.1
+          - rails7.2
+          - rails8.0
+          - rails8.1
         ruby:
-          - "3.0"
-          - "3.1"
-          - "3.2"
           - "3.3"
+          - "3.4"
+          - "4.0"
         backend:
           - active_record
           - mongoid
+        devise:
+          - "4.9.4"
+          - "5.0.3"
+        exclude:
+          - gemfile: "rails8.0"
+            devise: "4.9.4"
+          - gemfile: "rails8.1"
+            devise: "4.9.4"
+          - ruby: "3.4"
+            devise: "4.9.4"
+          - ruby: "4.0"
+            devise: "4.9.4"
+
     name: ${{ matrix.gemfile }}, ruby ${{ matrix.ruby }}, ${{ matrix.backend }}
     runs-on: ubuntu-latest
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
       BACKEND: ${{ matrix.backend }}
+      DEVISE_VERSION: ${{ matrix.devise }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### 1.9.0
+Remove Rails 6.1, 7.0 and 7.1 support
+
+Remove Ruby 3.0, 3.1 and 3.2 support
+
+Add Rails 7.2, 8.0 and 8.1 support
+
+Add Ruby 3.4 and 4.0 support
+
+Support Devise config.authentication_keys in hash format
+
 ### 1.8.1
 
 Remove Rails 5.2 and 6.0 support

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 6.1.0"
-gem "mongoid"
-gem "sqlite3", "~> 1.4"
-
-gemspec path: "../"

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 7.0.2"
-gem "mongoid"
-gem "sqlite3", "~> 1.4"
-
-gemspec path: "../"

--- a/gemfiles/rails7.1.gemfile
+++ b/gemfiles/rails7.1.gemfile
@@ -1,7 +1,0 @@
-source "https://rubygems.org"
-
-gem "rails", "~> 7.1.3"
-gem "mongoid"
-gem "sqlite3", "~> 1.4"
-
-gemspec path: "../"

--- a/gemfiles/rails7.2.gemfile
+++ b/gemfiles/rails7.2.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 7.2.3"
+gem "mongoid"
+gem "sqlite3", "~> 2.9"
+gem "devise", ENV["DEVISE_VERSION"]
+
+gemspec path: "../"

--- a/gemfiles/rails8.0.gemfile
+++ b/gemfiles/rails8.0.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 8.0.5"
+gem "mongoid"
+gem "sqlite3", "~> 2.9"
+gem "devise", ENV["DEVISE_VERSION"]
+
+gemspec path: "../"

--- a/gemfiles/rails8.1.gemfile
+++ b/gemfiles/rails8.1.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem "rails", "~> 8.1.3"
+gem "mongoid"
+gem "sqlite3", "~> 2.9"
+gem "devise", ENV["DEVISE_VERSION"]
+
+gemspec path: "../"

--- a/lib/tiddle/strategy.rb
+++ b/lib/tiddle/strategy.rb
@@ -53,7 +53,11 @@ module Devise
       end
 
       def authentication_keys
-        mapping.to.authentication_keys
+        if mapping.to.authentication_keys.is_a?(Hash)
+          mapping.to.authentication_keys.keys
+        else
+          mapping.to.authentication_keys
+        end
       end
 
       def touch_token(token)

--- a/lib/tiddle/version.rb
+++ b/lib/tiddle/version.rb
@@ -1,3 +1,3 @@
 module Tiddle
-  VERSION = "1.8.1".freeze
+  VERSION = "1.9.0".freeze
 end

--- a/spec/strategy_spec.rb
+++ b/spec/strategy_spec.rb
@@ -181,6 +181,35 @@ describe "Authentication using Tiddle strategy", type: :request do
     end
   end
 
+  describe "when authentication_keys is a hash" do
+    before do
+      Devise.setup do |config|
+        config.authentication_keys = { email: true }
+      end
+
+      @user = User.create!(
+        email: "test@example.com",
+        password: "12345678"
+      )
+      @token = Tiddle.create_and_return_token(@user, FakeRequest.new)
+    end
+
+    after do
+      Devise.setup do |config|
+        config.authentication_keys = [:email]
+      end
+    end
+
+    it "allows to access endpoints which require authentication with valid \
+      nick name and token" do
+      get(
+        secrets_path,
+        headers: { "X-USER-EMAIL" => "test@example.com", "X-USER-TOKEN" => @token }
+      )
+      expect(response.status).to eq 200
+    end
+  end
+
   context "when token has expires_in set up" do
     before do
       @user = User.create!(email: "test@example.com", password: "12345678")

--- a/spec/support/backend.rb
+++ b/spec/support/backend.rb
@@ -23,10 +23,7 @@ module Backend
       # Do initial migration
       path = File.expand_path("../rails_app_active_record/db/migrate/", File.dirname(__FILE__))
 
-      ActiveRecord::MigrationContext.new(
-        path,
-        ActiveRecord::SchemaMigration
-      ).migrate
+      ActiveRecord::MigrationContext.new(path).migrate
     end
   end
 

--- a/tiddle.gemspec
+++ b/tiddle.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '>= 3.0.0'
+  spec.required_ruby_version = '>= 3.2.0'
 
-  spec.add_dependency "devise", ">= 4.0.0.rc1", "< 5"
-  spec.add_dependency "activerecord", ">= 6.1.0"
+  spec.add_dependency "devise", ">= 4.0.0.rc1", "< 6"
+  spec.add_dependency "activerecord", ">= 7.2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
Also adds Ruby 3.4 & 4.0 support.
Removes Rails 6.1, 7.0 and 7.1 support as these are no longer supported.
Removes Ruby 3.0, 3.1 and 3.2 support as these are no longer supported.
Adds support for `config.authentication_keys` in [hash format](https://github.com/heartcombo/devise/blob/8054ad55c3d1b0602d3654cf0dfd065491f271b7/lib/generators/templates/devise.rb#L47).